### PR TITLE
Refs #248: remove font-size:small for definitions

### DIFF
--- a/wwwbase/styles/polar.css
+++ b/wwwbase/styles/polar.css
@@ -160,7 +160,6 @@ span.stopWords {
 
 span.def {
   cursor: pointer;
-  font-size: small;
 }
 
 h4 {


### PR DESCRIPTION
Polar skin looks vintage, so a vintage font should be used on it.
I preserved the "font-family: serif", instead of using "Open Sans" font.
I've increased the font size for definitions by deleting the "font-size: small" declaration.
