### PR TITLE
Add spacing for favorite definitions

### DIFF
--- a/templates/cuvinte-favorite.tpl
+++ b/templates/cuvinte-favorite.tpl
@@ -17,7 +17,7 @@
             șterge
           </a>
         </dt>
-        <dd data-idx="{$i}">{$row->html}</dd>
+        <dd class="favoriteDefs" data-idx="{$i}">{$row->html}</dd>
       {/foreach}
     {else}
       Nu aveți niciun cuvânt favorit.

--- a/wwwbase/css/main.css
+++ b/wwwbase/css/main.css
@@ -200,6 +200,11 @@ p.def {
   padding: 3px 5px;
 }
 
+/*********** favorites ***********/
+
+dd.favoriteDefs {
+  margin-bottom: 1em;
+}
 
 /*********** misc helpers ***********/
 


### PR DESCRIPTION
Favorite definitions need a spacing between them, easier to read and manage.