### PR TITLE
Definition spoofing support.

### DIFF
--- a/dex.conf.sample
+++ b/dex.conf.sample
@@ -58,6 +58,17 @@ aprilFoolsDay = 0
 ; Call to action for occasional activism. Specify a template to include, or false to turn off.
 callToAction = false
 
+; Custom definitions. Results will be returned as if the corresponding word was searched for.
+spoofEnabled = false
+
+; Will lowercase and remove diacritics from the search word so 'Mașină', 'mașină',
+; 'masină' and 'masina' will all match the same 'masina' defined here.
+; If set to false you will need to provide a mapping for each case. Default is true.
+; spoofNormalize = true
+
+; spoofWords["adevarat"] = "fals"
+; spoofWords["fals"] = "adevarat"
+
 ; API formats
 
 ; Enable XML response when appending /xml to the definition URL

--- a/wwwbase/search.php
+++ b/wwwbase/search.php
@@ -96,7 +96,7 @@ if ($cuv) {
 
 if(SPOOF_ENABLED && $cuv) {
   $cuv_normalized = SPOOF_NORMALIZE ? mb_strtolower(StringUtil::unicodeToLatin($cuv)) : $cuv;
-  $cuv_spoofed = SPOOF_WORDS[$cuv_normalized];
+  $cuv_spoofed = @SPOOF_WORDS[$cuv_normalized];
   if ($cuv_spoofed) {
     $cuv_spoofed_hasDiacritics = $hasDiacritics || StringUtil::analyzeQuery($cuv_spoofed)[0];
   }
@@ -267,9 +267,9 @@ $results = SearchResult::mapDefinitionArray($definitions);
 if(SPOOF_ENABLED && $cuv_spoofed) {
 
   function replaceSpoofedWord($definition, $cuv) {
-    $pattern = '/<b>(.*)<\/b>(\s.*)/';
+    $pattern = '/<b>(.*)<\/b>(.*?)/U';
     $replacement = sprintf('<b>%s</b>${2}', mb_strtoupper($cuv));
-    $definition->htmlRep = preg_replace($pattern, $replacement, $definition->htmlRep);
+    $definition->htmlRep = preg_replace($pattern, $replacement, $definition->htmlRep, 1);
     return $definition;
   }
 


### PR DESCRIPTION
Also works for direct entries as the word is part of the URL and can be used to fetch a spoofed definition (line `187`).

The first `<b>` tag of the definition `htmlRep` is replaced by the word that was searched for. All custom markup is lost as a result. (`<sup>`, accents...).

Setting `spoofNormalize` to `false` will give more control over the definition, for each form of the word, but will also require defining a mapping for each form. 