### PR TITLE
Scos kwyjibo de pe pagina de Scrabble

### DIFF
--- a/templates/scrabble.tpl
+++ b/templates/scrabble.tpl
@@ -13,7 +13,7 @@
       {assign var="selectedLocVersion" value=$selectedLocVersion|default:null}
 
       <p>
-        Joci Scrabble și prietenii tăi nu cred că <em>kwyjibo</em> este un cuvânt perfect legal? Tastează cuvântul tău ca să le arăți cine e șeful.
+        Joci Scrabble și prietenii tăi nu cred că <em>schwyz</em> este un cuvânt perfect legal? Tastează cuvântul tău ca să le arăți cine e șeful.
       </p>
 
       <form action="scrabble" method="get">
@@ -24,7 +24,7 @@
           {else}
             <div class="form-group">
           {/if}
-          <input class="scrabbleSearchField form-control" type="text" name="form" placeholder="kwyjibo" value="{$form|default:""|escape}" autofocus>
+          <input class="scrabbleSearchField form-control" type="text" name="form" placeholder="schwyz" value="{$form|default:""|escape}" autofocus>
           {if isset($data)}
             {if count($data)}
               <span class="form-control-feedback glyphicon glyphicon-ok"></span>


### PR DESCRIPTION
Textul de pe [pagina de Scrabble](https://dexonline.ro/scrabble) pare să sugereze că _kwyjibo_ este un cuvânt valid, însă verificarea eșuează (cu toate versiunile). În plus, nu l-am găsit nici în fișierele cu listele oficiale de cuvinte și nici la căutarea normală în dicționare.

L-am înlocuit cu alt cuvânt în pull requestul ăsta, dar poate nu asta este soluția corectă. Oricum, textul de acum este un pic înșelător. ^^