### PR TITLE
Changed escaping sequence of reserved chars in bulkReplace.php

### DIFF
--- a/wwwbase/admin/bulkReplace.php
+++ b/wwwbase/admin/bulkReplace.php
@@ -18,15 +18,17 @@ $saveButton = Request::has('saveButton');
 
 if (DebugInfo::isEnabled()){  DebugInfo::init(); }
 
-// Escape literal percent signs. Use | as escape character so that constructs like
-// \% (which in dexonline notation mean "literal percent sign") are unaffected.
-$reservedChars = array('%', '_');
-$escapedChars = array('¦%', '¦_');
-$mysqlSearch = str_replace($reservedChars, $escapedChars, $search);
-
+// Use | to escape MySQL special characters so that constructs and chars like
+// \% , _ , | (which in dexonline notation means: "literal percent sign", latex 
+// convention for subscript, the pipe itself) remains unaffected.
+$replaceChars = array('%' => '|%', 
+                      '_' => '|_', 
+                      '|' => '||'); 
+$mysqlSearch = strtr($search, array_combine(array_keys($replaceChars), array_values($replaceChars)));
+  
 $query = Model::factory('Definition')
        ->where_in('status', [Definition::ST_ACTIVE, Definition::ST_HIDDEN])
-       ->where_raw('(binary internalRep like ? escape "¦")', ["%{$mysqlSearch}%"]);
+       ->where_raw('(binary internalRep like ? escape "|")', ["%{$mysqlSearch}%"]);
 if ($sourceId) {
   $query = $query->where('sourceId', $sourceId);
 }


### PR DESCRIPTION
Turns out that ¦ is not suitable for escaping. Duh!