### PR TITLE
Character popup for editors.

### DIFF
--- a/phplib/SmartyWrap.php
+++ b/phplib/SmartyWrap.php
@@ -74,7 +74,7 @@ class SmartyWrap {
 			'third-party/bootstrap-datepicker3.min.css'
 		],
 	];
-  private static $jsMap = [
+	private static $jsMap = [
 		'jquery' => [
 			'third-party/jquery-1.12.4.min.js'
 		],
@@ -142,6 +142,9 @@ class SmartyWrap {
 		'hotkeys' => [
 			'third-party/jquery.hotkeys.js',
 			'hotkeys.js',
+		],
+		'charmap' => [
+			'charmap.js',
 		],
 		'callToAction' => [
 			'callToAction.js'
@@ -316,7 +319,7 @@ class SmartyWrap {
       self::assign('callToAction', true);
     }
     if (User::can(User::PRIV_ANY)) {
-      self::addJs('admin', 'hotkeys', 'sprintf');
+      self::addJs('admin', 'hotkeys', 'charmap', 'sprintf');
     }
     if (Session::userPrefers(Preferences::PRIVATE_MODE)) {
       self::addCss('privateMode');

--- a/phplib/SmartyWrap.php
+++ b/phplib/SmartyWrap.php
@@ -319,7 +319,7 @@ class SmartyWrap {
       self::assign('callToAction', true);
     }
     if (User::can(User::PRIV_ANY)) {
-      self::addJs('admin', 'hotkeys', 'charmap', 'sprintf');
+      self::addJs('admin', 'hotkeys', 'cookie', 'charmap', 'sprintf');
     }
     if (Session::userPrefers(Preferences::PRIVATE_MODE)) {
       self::addCss('privateMode');

--- a/templates/admin/charmap.tpl
+++ b/templates/admin/charmap.tpl
@@ -1,0 +1,19 @@
+<div class="modal fade" tabindex="-1" role="dialog" id="modal-charmap">
+	<div class="modal-dialog" role="document">
+		<div class="modal-content">
+			<div class="modal-header">
+				<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+				<h4 class="modal-title">Inserează semn glifă</h4>
+			</div>
+			<div class="modal-body">
+				<span data-role="buttons"></span>
+				<button type="button" id="editButton" class="btn btn-default">Editează</button>
+				<div data-role="edit">
+					<p>Adaugă caracterele în căsuța de mai jos, unul pe linie.</p>
+					<textarea id="editBox" class="form-control" rows="10"></textarea>
+					<button type="button" id="saveButton" class="btn btn-default">Salveză</button>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/templates/admin/charmap.tpl
+++ b/templates/admin/charmap.tpl
@@ -7,11 +7,11 @@
 			</div>
 			<div class="modal-body">
 				<span data-role="buttons"></span>
-				<button type="button" id="editButton" class="btn btn-default">Editează</button>
+				<button type="button" id="editButton" class="btn btn-default">editează</button>
 				<div data-role="edit">
 					<p>Adaugă caracterele în căsuța de mai jos, unul pe linie.</p>
 					<textarea id="editBox" class="form-control" rows="10"></textarea>
-					<button type="button" id="saveButton" class="btn btn-default">Salveză</button>
+					<button type="button" id="saveButton" class="btn btn-default">salvează</button>
 				</div>
 			</div>
 		</div>

--- a/templates/layout-admin.tpl
+++ b/templates/layout-admin.tpl
@@ -2,4 +2,8 @@
 
 {block "banner"}{/block}
 {block "search"}{/block}
+{block "content"}
+	{include "admin/charmap.tpl"}
+	{$smarty.block.child}
+{/block}
 {block "footer"}{/block}

--- a/wwwbase/js/charmap.js
+++ b/wwwbase/js/charmap.js
@@ -1,5 +1,37 @@
 (function(){
 
+	// adapted from https://stackoverflow.com/questions/11076975/insert-text-into-textarea-at-cursor-position-javascript/41426040#41426040
+	function insertAtCursor(myField, myValue) {
+		//IE support
+		if (document.selection) {
+			myField.focus();
+			sel = document.selection.createRange();
+			sel.text = myValue;
+		}
+		// Microsoft Edge
+		else if(window.navigator.userAgent.indexOf("Edge") > -1) {
+			var startPos = myField.selectionStart;
+			var endPos = myField.selectionEnd;
+
+			myField.value = myField.value.substring(0, startPos)+ myValue
+				+ myField.value.substring(endPos, myField.value.length);
+
+			var pos = startPos + myValue.length;
+			myField.focus();
+			myField.setSelectionRange(pos, pos);
+		}
+		//MOZILLA and others
+		else if (myField.selectionStart || myField.selectionStart == '0') {
+			var startPos = myField.selectionStart;
+			var endPos = myField.selectionEnd;
+			myField.value = myField.value.substring(0, startPos)
+				+ myValue
+				+ myField.value.substring(endPos, myField.value.length);
+		} else {
+			myField.value += myValue;
+		}
+	}
+
 	var COOKIE = 'charmap';
 
 	var DEFAULT = ['á', 'à', 'ä'];
@@ -44,7 +76,10 @@
 
 		var target = this.target;
 		button.on('click', function() {
-			target.val(target.val() + chr);
+			// target is a jQuery element,
+			// insertAtCursor requires a DOM element
+			// so we use .get(0).
+			insertAtCursor(target.get(0), chr);
 		});
 
 		return button;

--- a/wwwbase/js/charmap.js
+++ b/wwwbase/js/charmap.js
@@ -1,0 +1,107 @@
+(function(){
+
+	var COOKIE = 'charmap';
+
+	var DEFAULT = ['á', 'à', 'ä'];
+	var BUTTON = '<button class="btn btn-default" data-dismiss="modal">';
+
+
+	// character read/edit logic
+	var Charmap = function() {
+		this._cookie_json = $.cookie.json;
+	}
+
+	Charmap.prototype.read = function() {
+		$.cookie.json = true;
+		var value = $.cookie(COOKIE) || [];
+		$.cookie.json = this._cookie_json;
+		return value;
+	}
+
+	Charmap.prototype.edit = function(value) {
+		$.cookie.json = true;
+		$.cookie(COOKIE, value, { expires: 36500 });
+		$.cookie.json = this._cookie_json;
+	}
+
+	Charmap.prototype.all = function() {
+		return DEFAULT.concat(this.read());
+	}
+
+
+	// charmap buttons
+	var CharmapButtons = function(target) {
+		this.target = target;
+	}
+
+	CharmapButtons.prototype.buttons = function(chars) {
+		return chars.map(this.button.bind(this));
+	}
+
+	CharmapButtons.prototype.button = function(chr) {
+		var button = $(BUTTON);
+		button.text(chr);
+
+		var target = this.target;
+		button.on('click', function() {
+			target.val(target.val() + chr);
+		});
+
+		return button;
+	}
+
+
+	// modal display and logic
+	var CharmapModal = function(target, charmap, buttons) {
+		this.target = $(target);
+		this.charmap = charmap;
+		this.buttons = buttons;
+
+		this.editArea = $('[data-role=edit]', this.target);
+		this.editArea.hide();
+
+		this.editBox = $('#editBox', this.target);
+		this.editButton = $('#editButton', this.target).on('click', this.edit.bind(this));
+		this.saveButton = $('#saveButton', this.target).on('click', this.save.bind(this));
+
+		this.update();
+	}
+
+	CharmapModal.prototype.update = function() {
+		$('[data-role=buttons]', this.target)
+			.html(this.buttons.buttons(this.charmap.all()));
+	}
+
+	CharmapModal.prototype.show = function() {
+		this.target.modal();
+	}
+
+	CharmapModal.prototype.edit = function() {
+		this.editButton.hide();
+		this.editBox.val(this.charmap.read().join('\n'));
+		this.editArea.show();
+	}
+
+	CharmapModal.prototype.save = function() {
+		var value = this.editBox.val();
+		var to_save = value.split(/\r\n|\r|\n/g).filter(function(val) {
+			return val.trim() !== "";
+		});
+		this.charmap.edit(to_save);
+		this.update();
+		this.editArea.hide();
+		this.editButton.show();
+	}
+
+	var CHARMAP = new Charmap();
+	var show = function(sel_modal, insert_target) {
+		var buttons = new CharmapButtons($(insert_target));
+		var modal = new CharmapModal(sel_modal, CHARMAP, buttons);
+		modal.show();
+	}
+
+	window.Charmap = {
+		show: show,
+	};
+
+})();

--- a/wwwbase/js/hotkeys.js
+++ b/wwwbase/js/hotkeys.js
@@ -24,6 +24,8 @@ $(function() {
 
     $(document).bind('keydown', 'alt+p', clickPreviewTags);
 
+    $(document).bind('keydown', 'alt+ctrl+e', function(evt) { Charmap.show('#modal-charmap', evt.target); });
+
     $('a.hotkeyLink').click(hotkeyLinkClick);
   }
 


### PR DESCRIPTION
This includes the changes from pull request https://github.com/dexonline/dexonline/pull/668, that one should be tested and merged first.

 - Button popup for custom characters. 
   - adding charmap.js to resources, loaded for editors
   - keybinding set to `ctrl+alt+e`

Custom data is saved in a `charmap` cookie, valid for a century.