### PR TITLE
[refs #671] charmap and keybindings in TinyMCE

### DIFF
--- a/wwwbase/js/charmap.js
+++ b/wwwbase/js/charmap.js
@@ -37,7 +37,11 @@
 		else {
 			myField.value += myValue;
 		}
-	}
+	};
+
+	function insertAtTinyMCECursor(editor, chr) {
+		editor.insertContent(chr);
+	};
 
 	var COOKIE = 'charmap';
 
@@ -80,7 +84,19 @@
 
 	// charmap buttons
 	var CharmapButtons = function(target) {
-		this.target = target;
+		var is_tinymce = target.hasClass('mce-content-body');
+		this.inserter = (
+			is_tinymce
+			? function(chr) {
+				insertAtTinyMCECursor(tinymce.activeEditor, chr);
+			}
+			: function(chr) {
+				// target is a jQuery element,
+				// insertAtCursor requires a DOM element
+				// so we use .get(0).
+				insertAtCursor(target.get(0), chr);
+			}
+		)
 	}
 
 	CharmapButtons.prototype.buttons = function(chars) {
@@ -91,13 +107,8 @@
 		var button = $(BUTTON);
 		button.text(chr);
 
-		var target = this.target;
-		button.on('click', function() {
-			// target is a jQuery element,
-			// insertAtCursor requires a DOM element
-			// so we use .get(0).
-			insertAtCursor(target.get(0), chr);
-		});
+		var inserter = this.inserter;
+		button.on('click', function() { inserter(chr) });
 
 		return button;
 	}

--- a/wwwbase/js/tinymce.js
+++ b/wwwbase/js/tinymce.js
@@ -47,6 +47,12 @@ $(function() {
 
     editor.on('init', function() {
 
+      var _doc = $(document);
+      // Trigger keyboard events on parent document.
+      // This is done so that keybindings work even when TinyMCE has focus.
+      // In this case evt.target will be .mce-content-body.
+      editor.on('keydown', function(evt) { _doc.trigger(evt); });
+
       // Register a "spaced" format
       editor.formatter.register('spaced', {
         inline : 'span',
@@ -100,7 +106,7 @@ $(function() {
     s = s.replace(/\\%/g, '~~~SAVE~~~'); // move \% out of the way
     s = s.replace(/%([^%]*)%/g, '<span class="spaced">$1</span>');
     s = s.replace(/~~~SAVE~~~/g, '\\%'); // restore \%
-      
+
     s = s.replace(/\^(\d)/g, '<sup>$1</sup>');
     s = s.replace(/_(\d)/g, '<sub>$1</sub>');
     s = s.replace(/\^\{([^}]*)\}/g, '<sup>$1</sup>');


### PR DESCRIPTION
`keydown` events in the TinyMCE editor are now re-triggered on `$(document)`. This allows keybindings to work.
Adapted charmap to correctly handle tinymce as target.