### PR TITLE
fix for horizontal overflow

### DIFF
--- a/wwwbase/css/main.css
+++ b/wwwbase/css/main.css
@@ -108,6 +108,7 @@
 
 header .banner-section {
   margin-bottom: 0;
+  max-width: 100%;
 }
 
 .fakeBanner {


### PR DESCRIPTION
The issue appears on most of the pages that have the .banner-section, eg: https://dexonline.ro/cuvantul-lunii/2018/07, https://dexonline.ro/articole