### PR TITLE
Improved bulkReplace.

### DIFF
--- a/phplib/Constant.php
+++ b/phplib/Constant.php
@@ -51,6 +51,8 @@ class Constant {
     '/▶(.*?)◀/s' => '',                                                  // remove unwanted parts of definition
     '/(?<!\\\\)"([^"]*)"/' => '„$1”',                                     // "x" => „x” - romanian quoting style
     '/(?<!\\\\)\{{2}(.*)(?<![+])\}{2}/U' => [ 'FootnoteHtmlizer' ],      // {{footnote}}
+    '/(?<!\\\\)\{-(.*)-\}/' => [ 'DeleteHtmlizer' ],                       // deletions {-foo-}
+    '/(?<!\\\\)\{\+(.*)\+\}/' => [ 'InsertHtmlizer' ],                     // insertions {+foo+}
     '/(?<!\\\\)##(.*)(?<!\\\\)##/Us' => '$1',                            // ##non-abbreviation##
     '/\{#(.*)#\}/Us' => '<span class="ambigAbbrev">$1</span>',           // {#abbreviation#} for review
     '/(?<!\\\\)#(.*)(?<!\\\\)#/Us' => [ 'AbbrevHtmlizer' ],              // #abbreviation#
@@ -61,8 +63,6 @@ class Constant {
     '/(?<!\\\\)\^\{([^}]*)\}/' => '<sup>$1</sup>',                       // superscript ^{a b c}
     '/(?<!\\\\)_(\d)/' => '<sub>$1</sub>',                               // subscript _123
     '/(?<!\\\\)_\{([^}]*)\}/' => '<sub>$1</sub>',                        // superscript _{a b c}
-    '/(?<!\\\\)\{-([^}]*)-\}/' => '<del>$1</del>',                       // deletions {-foo-}
-    '/(?<!\\\\)\{\+([^}]*)\+\}/' => '<ins>$1</ins>',                     // insertions {+foo+}
     '/' . self::PARSING_ERROR_MARKER . '/' => '',
 
     // cycle CSS class {cfoo|0c}, used to highlight full-text search matches

--- a/phplib/Constant.php
+++ b/phplib/Constant.php
@@ -51,8 +51,8 @@ class Constant {
     '/▶(.*?)◀/s' => '',                                                  // remove unwanted parts of definition
     '/(?<!\\\\)"([^"]*)"/' => '„$1”',                                     // "x" => „x” - romanian quoting style
     '/(?<!\\\\)\{{2}(.*)(?<![+])\}{2}/U' => [ 'FootnoteHtmlizer' ],      // {{footnote}}
-    '/(?<!\\\\)\{-(.*)-\}/' => [ 'DeleteHtmlizer' ],                       // deletions {-foo-}
-    '/(?<!\\\\)\{\+(.*)\+\}/' => [ 'InsertHtmlizer' ],                     // insertions {+foo+}
+    '/(?<!\\\\)\{-(.*)-\}/U' => [ 'DeleteHtmlizer' ],                       // deletions {-foo-}
+    '/(?<!\\\\)\{\+(.*)\+\}/U' => [ 'InsertHtmlizer' ],                     // insertions {+foo+}
     '/(?<!\\\\)##(.*)(?<!\\\\)##/Us' => '$1',                            // ##non-abbreviation##
     '/\{#(.*)#\}/Us' => '<span class="ambigAbbrev">$1</span>',           // {#abbreviation#} for review
     '/(?<!\\\\)#(.*)(?<!\\\\)#/Us' => [ 'AbbrevHtmlizer' ],              // #abbreviation#

--- a/phplib/htmlize/DeleteHtmlizer.php
+++ b/phplib/htmlize/DeleteHtmlizer.php
@@ -1,0 +1,16 @@
+<?php
+
+class DeleteHtmlizer extends Htmlizer {
+  private $tags = "$@%";
+
+  // htmlize one deleted chunk formatted as {-text-}
+  function htmlize($match) {
+    $match = str_replace(" ","␣", $match);
+    return sprintf('<del>%s</del>', $this->closeTags($match[1]));
+  }
+
+  function closeTags($s) {
+    $reversedTags = strrev(preg_replace('/[^'.$this->tags.']/u', '', $s));
+    return $s.$reversedTags;
+  }
+}

--- a/phplib/htmlize/InsertHtmlizer.php
+++ b/phplib/htmlize/InsertHtmlizer.php
@@ -1,0 +1,10 @@
+<?php
+
+class InsertHtmlizer extends Htmlizer {
+
+  // htmlize one inserted chunk formatted as {+text+}
+  function htmlize($match) {
+    $match = str_replace(" ","␣", $match);
+    return sprintf('<ins>%s</ins>', $match[1]);
+  }
+}

--- a/wwwbase/admin/bulkReplace.php
+++ b/wwwbase/admin/bulkReplace.php
@@ -160,7 +160,6 @@ SmartyWrap::assign('de', Str::getAmountPreposition(count($objects)));
 SmartyWrap::assign('modUser', User::getActive());
 SmartyWrap::assign('objects', $objects);
 SmartyWrap::assign('structuredChanged', count($structuredIds));
-SmartyWrap::addJs('diff');
 SmartyWrap::addCss('admin', 'diff');
 SmartyWrap::display('admin/bulkReplace.tpl');
 


### PR DESCRIPTION
	- eliminates the delay of diff.js when many occurrences have been found.
	- correctly leaves #abbrev# fields untouched inside <del> and <ins> tags.

Above - old behavior ::: Below - new behavior:
![dexonline bulkreplace 1](https://user-images.githubusercontent.com/16460700/47784007-3e4e7a80-dcfc-11e8-898b-0e08fe9d8560.jpg)
