### PR TITLE
Make single-line regexp for del and ins htmlizers.

### DIFF
--- a/phplib/Constant.php
+++ b/phplib/Constant.php
@@ -4,6 +4,20 @@
 
 class Constant {
   const PARSING_ERROR_MARKER = "◼◼◼";
+
+  /* https://en.wikipedia.org/wiki/Whitespace_character */
+  const SPACES = [
+    'thin' => "\u{2009}",        /* U+2009; &#8201; &thinsp; */
+    'hair' => "\u{200A}",        /* U+200A; &#8202; &hairsp; */
+    'zero-width' => " \u{200B}",  /* U+200B; &#8203; &NegativeMediumSpace; */
+    'zwnj' => "\u{200C}",        /* U+200C; &#8204; &zwnj; */
+    'zwj' => "\u{200D}",         /* U+200D; &#8205; &zwj; */
+    'punctuation' => "\u{2008}", /* U+2008; &#8200; &puncsp; */
+    'nobreak' => "\u{00A0}",     /* U+00A0; &#160; &nbsp;*/
+    'regular' => "\u{0020}",     /* U+0020; &#32; */
+    ];
+  const OPENBOX = "\u{2423}";    /* U+2423; &#9251; */
+
   const CLEANUP_PATTERNS = [
     '/(?<!\\\\)ş/'   => 'ș',
     '/(?<!\\\\)Ş/'   => 'Ș',
@@ -51,8 +65,8 @@ class Constant {
     '/▶(.*?)◀/s' => '',                                                  // remove unwanted parts of definition
     '/(?<!\\\\)"([^"]*)"/' => '„$1”',                                     // "x" => „x” - romanian quoting style
     '/(?<!\\\\)\{{2}(.*)(?<![+])\}{2}/U' => [ 'FootnoteHtmlizer' ],      // {{footnote}}
-    '/(?<!\\\\)\{-(.*)-\}/U' => [ 'DeleteHtmlizer' ],                       // deletions {-foo-}
-    '/(?<!\\\\)\{\+(.*)\+\}/U' => [ 'InsertHtmlizer' ],                     // insertions {+foo+}
+    '/(?<!\\\\)\{-(.*)-\}/Us' => [ 'DeleteHtmlizer' ],                       // deletions {-foo-}
+    '/(?<!\\\\)\{\+(.*)\+\}/Us' => [ 'InsertHtmlizer' ],                     // insertions {+foo+}
     '/(?<!\\\\)##(.*)(?<!\\\\)##/Us' => '$1',                            // ##non-abbreviation##
     '/\{#(.*)#\}/Us' => '<span class="ambigAbbrev">$1</span>',           // {#abbreviation#} for review
     '/(?<!\\\\)#(.*)(?<!\\\\)#/Us' => [ 'AbbrevHtmlizer' ],              // #abbreviation#

--- a/phplib/htmlize/DeleteHtmlizer.php
+++ b/phplib/htmlize/DeleteHtmlizer.php
@@ -5,12 +5,16 @@ class DeleteHtmlizer extends Htmlizer {
 
   // htmlize one deleted chunk formatted as {-text-}
   function htmlize($match) {
-    $match = str_replace(" ","␣", $match);
+    $match = str_replace(Constant::SPACES['regular'], Constant::OPENBOX . Constant::SPACES['hair'], $match);
     return sprintf('<del>%s</del>', $this->closeTags($match[1]));
   }
 
+  // needed to circumvent html breaking
   function closeTags($s) {
     $reversedTags = strrev(preg_replace('/[^'.$this->tags.']/u', '', $s));
-    return $s.$reversedTags;
+
+    // recursively removing empty $tags
+    $finalTags = preg_replace('/(['.$this->tags.'])([\s]*?|(?R))\1/miUs', '', $reversedTags);
+    return $s.$finalTags;
   }
 }

--- a/phplib/htmlize/InsertHtmlizer.php
+++ b/phplib/htmlize/InsertHtmlizer.php
@@ -4,7 +4,7 @@ class InsertHtmlizer extends Htmlizer {
 
   // htmlize one inserted chunk formatted as {+text+}
   function htmlize($match) {
-    $match = str_replace(" ","␣", $match);
+    $match = str_replace(Constant::SPACES['regular'], Constant::OPENBOX . Constant::SPACES['hair'], $match);
     return sprintf('<ins>%s</ins>', $match[1]);
   }
 }

--- a/wwwbase/istoria-definitiei.php
+++ b/wwwbase/istoria-definitiei.php
@@ -37,6 +37,5 @@ $changeSets = array_reverse($changeSets); // newest changes first
 
 SmartyWrap::assign('def', $def);
 SmartyWrap::assign('changeSets', $changeSets);
-SmartyWrap::addJs('diff');
 SmartyWrap::addCss('diff');
 SmartyWrap::display('istoria-definitiei.tpl');


### PR DESCRIPTION
Definition history does not need diff.js anymore.
Create app-wide different SPACE constants.
Improved DeleteHtmlizer.