### PR TITLE
PageIndex-IVO-III

### DIFF
--- a/lib/models/PageIndex.php
+++ b/lib/models/PageIndex.php
@@ -12,8 +12,10 @@ class PageIndex extends BaseObject {
     }
 
     // source-specific fixes
-    if ($sourceId == 42) {
-      // Șăineanu disregards diacritics when sorting, so convert the word as well.
+    $sources = array(42, 82); // Șăineanu and IVO-III
+    if (in_array($sourceId, $sources)) {
+      // Șăineanu and other dictionaries disregard diacritics when sorting,
+      // so convert the word as well.
       $word = Str::unicodeToLatin($word);
     }
 

--- a/patches/00298.php
+++ b/patches/00298.php
@@ -1,0 +1,15 @@
+<?php
+require_once __DIR__ . '/../lib/Core.php';
+const SOURCE_ID = 82; // Converting IVO-III
+
+$pi = Model::factory('PageIndex')
+    ->where('sourceId', SOURCE_ID)
+    ->find_many();
+
+foreach ($pi as $p) {
+  $word = Str::unicodeToLatin($p->word);
+  Log::info('Converting in PageIndex at id [%d] word [%s] to latin charset as [%s]',
+            $p->id, $p->word, $word);
+  $p->word = $word;
+  $p->save();
+}


### PR DESCRIPTION
Converting words in PageIndex table from IVO-III dictionary to non-diacritical character forms.
Adjustments to the PageIndex class in accordance to the above.