### PR TITLE
getSimilarRecord-fix

### DIFF
--- a/www/js/autoload/definition/edit.js
+++ b/www/js/autoload/definition/edit.js
@@ -159,7 +159,6 @@ $(function() {
 
   function getSourceId() {
     var sourceId = $('input[name=source]').length ? $('input[name=source]') : $('#sourceDropDown');
-    alert(sourceId.val());
     return sourceId.val();
   }
 

--- a/www/js/autoload/definition/edit.js
+++ b/www/js/autoload/definition/edit.js
@@ -57,7 +57,7 @@ $(function() {
     var data = {
       definitionId: $('input[name="definitionId"]').val(),
       internalRep: internalRep.val(),
-      sourceId: $('#sourceDropDown').val(),
+      sourceId: getSourceId(),
       entryIds: $('#entryIds').val(),
     };
     $.post(wwwRoot + 'ajax/getSimilarRecord.php', data, updateFields, 'json');
@@ -146,7 +146,7 @@ $(function() {
     var data = {
       definitionId: $('input[name="definitionId"]').val(),
       internalRep: internalRep.val(),
-      sourceId: $('#sourceDropDown').val(),
+      sourceId: getSourceId(),
     };
     $.post(wwwRoot + 'ajax/getEntriesForLexicon.php', data, function(resp) {
       $('#entryIds').val(null);
@@ -155,6 +155,12 @@ $(function() {
       }
       refreshSelect2('#entryIds', 'ajax/getEntriesById.php');
     });
+  }
+
+  function getSourceId() {
+    var sourceId = $('input[name=source]').length ? $('input[name=source]') : $('#sourceDropDown');
+    alert(sourceId.val());
+    return sourceId.val();
   }
 
   init();


### PR DESCRIPTION
Fix when sourceDropdown is replaced with a disabled field as a result of source.canModerate = false.