### PR TITLE
Ordered variants in frontend

### DIFF
--- a/lib/models/Entry.php
+++ b/lib/models/Entry.php
@@ -101,6 +101,7 @@ class Entry extends BaseObject implements DatedObject {
       ->where_not_equal('l.formNoAccent', $this->getShortDescription())
       ->group_by('l.formNoAccent')
       ->order_by_desc('el.main')
+      ->order_by_asc('el.lexemeRank')
       ->order_by_asc('l.formNoAccent')
       ->find_many();
     return $results;

--- a/lib/models/Tree.php
+++ b/lib/models/Tree.php
@@ -226,6 +226,7 @@ class Tree extends BaseObject implements DatedObject {
       ->where('te.treeId', $this->id)
       ->group_by('l.formNoAccent')
       ->order_by_desc('el.main')
+      ->order_by_asc('el.lexemeRank')
       ->order_by_asc('l.formNoAccent')
       ->find_many();
 


### PR DESCRIPTION
Variants are displayed in the lexemeRank order, specified by the editor in the edit-entry form.