### PR TITLE
Add search suggestions in OpenSearch format

### DIFF
--- a/www/ajax/searchComplete.php
+++ b/www/ajax/searchComplete.php
@@ -3,10 +3,15 @@ require_once '../../lib/Core.php';
 header("Content-Type: application/json");
 
 $term = Request::get('term');
+$type = Request::get('type');
 
 $use = Config::SEARCH_AC_ENABLED &&
   (mb_strlen($term) >= Config::SEARCH_AC_MIN_CHARS);
 
 $forms = $use ? Autocomplete::ac($term, Config::SEARCH_AC_LIMIT) : [];
 
-print json_encode($forms);
+if ($type === 'opensearch') {
+  print json_encode([$term, $forms]);
+} else {
+  print json_encode($forms);
+}


### PR DESCRIPTION
For use in browser extensions and OpenSearch description documents.

See documentation here: https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Suggestions/1.1/Draft%201.wiki#JSONformatted_search_suggestion_responses