### PR TITLE
Typo submission problems

### DIFF
--- a/templates/aggregate/dashboard.tpl
+++ b/templates/aggregate/dashboard.tpl
@@ -25,9 +25,11 @@
 
       </div>
 
+      {assign var="hasVisibleReports" value=false}
       <table class="table table-sm table-hover mb-0">
         {foreach $reports as $r}
           {if $r.count && User::can($r.privilege)}
+            {assign var="hasVisibleReports" value=true}
             <tr>
               <td>
                 {$r.text}
@@ -40,6 +42,13 @@
           {/if}
         {/foreach}
       </table>
+      {if !$hasVisibleReports}
+        <div class="card-body">
+          <p class="text-muted">
+            Nu există rapoarte de afișat.
+          </p>
+        </div>
+      {/if}
     </div>
   {/if}
 

--- a/www/js/autoload/entry/edit.js
+++ b/www/js/autoload/entry/edit.js
@@ -168,45 +168,14 @@ $(function() {
     return false;
   }
 
-  // TODO this duplicates some code from main.js:searchClickedWord()
   function prepareTypo(evt) {
     var id = evt.data.param;
-    //if ($(event.target).is('abbr')) return false;
-    var s = window.getSelection();
 
-    //if (!s.isCollapsed) return false;
-    var begin = /^\s/;
-    var end = /\s$/;
+    var sel = searchClickedWord(evt, false);
+    if (!sel) {
+      return;
+    }
 
-    var	d = document,
-        nA = s.anchorNode,
-        oA = s.anchorOffset,
-        nF = s.focusNode,
-        oF = s.focusOffset,
-        range = d.createRange();
-
-    range.setStart(nA,oA);
-    range.setEnd(nF,oF);
-
-    // Extend range to the next space or end of node
-    while(range.endOffset < range.endContainer.textContent.length &&
-          !end.test(range.toString())){
-            range.setEnd(range.endContainer, range.endOffset + 1);
-          }
-    // Extend range to the previous space or start of node
-    while(range.startOffset > 0 &&
-          !begin.test(range.toString())){
-            range.setStart(range.startContainer, range.startOffset - 1);
-          }
-
-    // Remove spaces
-    if(end.test(range.toString()) && range.endOffset > 0)
-      range.setEnd(range.endContainer, range.endOffset - 1);
-    if(begin.test(range.toString()))
-      range.setStart(range.startContainer, range.startOffset + 1);
-
-    // Assign range to selection
-    var sel = range.toString();
     var txt = $('#typoText_'+id).val();
     txt += txt ? ' • ' : '';
     $('#typoText_'+id).val(txt + sel);

--- a/www/js/dex.js
+++ b/www/js/dex.js
@@ -168,19 +168,39 @@ function shownTypoModal(event) {
   $('#typoSubmit').removeData('submitted'); // allow clicking the button again
 }
 
-function submitTypoForm() {
-  var text = $('#typoTextarea').val();
-  var defId = $('input[name="definitionId"]').val();
-  $.post(wwwRoot + 'ajax/typo.php',
-         { definitionId: defId, text: text, submit: 1 },
-         function() {
-           $('#typoModal').modal('hide');
-           $('#typoTextarea').val('');
-           var confModal = new bootstrap.Modal($('#typoConfModal'));
-           confModal.show();
-         });
+function submitTypoForm(event) {
+  event.preventDefault();
+
+  var triggerButton = document.activeElement;
+
+  if ($(triggerButton).is('#typoSubmit')) {
+    var text = $('#typoTextarea').val();
+    var defId = $('input[name="definitionId"]').val();
+
+    if (!text.trim()) {
+      alert('Vă rugăm descrieți problema în maximum 400 de caractere.');
+      return false;
+    }
+
+    $.post(
+      wwwRoot + 'ajax/typo.php',
+      { definitionId: defId, text: text, submit: 1 },
+      function () {
+        $('#typoModal').modal('hide');
+        $('#typoTextarea').val('');
+        var confModal = new bootstrap.Modal($('#typoConfModal'));
+        confModal.show();
+      }
+    );
+  } else {
+    $('#typoModal').modal('hide');
+  }
+
   return false;
 }
+
+// Attach the submit event to the form. If deleted, it will refresh the page.
+$(document).on('submit', '#typoHtmlForm', submitTypoForm);
 
 function toggle(id) {
   $('#' + id).stop().slideToggle();

--- a/www/js/dex.js
+++ b/www/js/dex.js
@@ -225,7 +225,7 @@ function endsWith(str, sub) {
 }
 
 /* adapted from http://stackoverflow.com/questions/7563169/detect-which-word-has-been-clicked-on-within-a-text */
-function searchClickedWord(event) {
+function searchClickedWord(event, redirect = false) {
   if ($(event.target).is('abbr')) return false;
   if ($(event.target).is('a')) {
     console.log(event.target.href);
@@ -271,7 +271,11 @@ function searchClickedWord(event) {
   }
 
   if (word) {
-    window.location = wwwRoot + 'definitie' + source + '/' + encodeURIComponent(word);
+    if (redirect) {
+      window.location = wwwRoot + 'definitie' + source + '/' + encodeURIComponent(word);
+    } else {
+      return word;
+    }
   }
 }
 


### PR DESCRIPTION
Acest pull request rezolva 3 probleme:

- Commit: _Fix Cancel button when closing typo submission form_
In momentul in care se semnala o greseala si se renunta prin click pe butonul "anuleaza", o modala cu "Vă mulțumim pentru semnalare!" aparea, ceea ce nu este de dorit.

- Commit: _Fix reports view when there is nothing to see_
Local, cand am logam ca administrator, in pagina moderatorului, sectiunea "Rapoarte" aparea, insa doar atat. Niciun raport afisat. Am adaugat un mesaj adecvat "Nu există rapoarte de afișat." pentru acele situatii. Nu stiu daca se intampla prea des in productie, dar cred ca e un lucru bun de avut.

- Commit: _Fix clicking a word stopping scanning at accent_
Rezolva #978 . 
A fost reutilizata functia _main.js:searchClickedWord()_, fapt care a fost marcat si ca TODO in code base.